### PR TITLE
Fix: Trying to get property 'userid' of non-object

### DIFF
--- a/rule.php
+++ b/rule.php
@@ -89,6 +89,10 @@ class quizaccess_failgrade extends quiz_access_rule_base {
      * attempt at this quiz.
      */
     public function is_finished($numprevattempts, $lastattempt) {
+        if ($numprevattempts === 0) {
+            return false;
+        }
+
         $item = grade_item::fetch([
             'courseid' => $this->quiz->course,
             'itemtype' => 'mod',


### PR DESCRIPTION
See https://github.com/rigao-alexandre/moodle-quizaccess_failgrade/issues/7
$lastattempt is false if $numprevattempts is 0 so $lastattempt->userid
results in an error.