### PR TITLE
10: Implement Backup API

### DIFF
--- a/backup/moodle2/backup_quizaccess_failgrade_subplugin.class.php
+++ b/backup/moodle2/backup_quizaccess_failgrade_subplugin.class.php
@@ -1,0 +1,49 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+
+require_once($CFG->dirroot . '/mod/quiz/backup/moodle2/backup_mod_quiz_access_subplugin.class.php');
+
+defined('MOODLE_INTERNAL') || die();
+
+
+/*
+ * @package   quizaccess_failgrade
+ * @copyright 2023 Leon Stringer
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+ 
+class backup_quizaccess_failgrade_subplugin extends backup_mod_quiz_access_subplugin {
+
+    protected function define_quiz_subplugin_structure() {
+
+        // Create XML elements.
+        $subplugin = $this->get_subplugin_element();
+        $subplugin_wrapper = new backup_nested_element($this->get_recommended_name());
+        $subplugin_table_settings = new backup_nested_element('quizaccess_failgrade',
+                null, array('failgradeenabled'));
+
+        // Connect XML elements into the tree.
+        $subplugin->add_child($subplugin_wrapper);
+        $subplugin_wrapper->add_child($subplugin_table_settings);
+
+        // Set source to populate the data.
+        $subplugin_table_settings->set_source_table('quizaccess_failgrade',
+                array('quizid' => backup::VAR_ACTIVITYID));
+
+        return $subplugin;
+    }
+}

--- a/backup/moodle2/restore_quizaccess_failgrade_subplugin.class.php
+++ b/backup/moodle2/restore_quizaccess_failgrade_subplugin.class.php
@@ -1,0 +1,54 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+
+require_once($CFG->dirroot . '/mod/quiz/backup/moodle2/restore_mod_quiz_access_subplugin.class.php');
+
+defined('MOODLE_INTERNAL') || die();
+
+
+/**
+ * Restore code for the quizaccess_failgrade plugin.
+ * @package   quizaccess_failgrade
+ * @copyright 2023 Leon Stringer
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+ 
+class restore_quizaccess_failgrade_subplugin extends restore_mod_quiz_access_subplugin {
+
+    protected function define_quiz_subplugin_structure() {
+
+        $paths = array();
+
+        $elename = $this->get_namefor('');
+        $elepath = $this->get_pathfor('/quizaccess_failgrade');
+        $paths[] = new restore_path_element($elename, $elepath);
+
+        return $paths;
+    }
+
+    /**
+     * Processes the quizaccess_failgrade element, if it is in the file.
+     * @param array $data the data read from the XML file.
+     */
+    public function process_quizaccess_failgrade($data) {
+        global $DB;
+
+        $data = (object)$data;
+        $data->quizid = $this->get_new_parentid('quiz');
+        $DB->insert_record('quizaccess_failgrade', $data);
+    }
+}


### PR DESCRIPTION
Implement Moodle Backup API methods based on those for quizaccess_reattemptchecker (see
https://github.com/terrycampbell/moodle-quizaccess_reattemptchecker).

Fix for issue #10 .